### PR TITLE
task: moving to the options pattern to configure the handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,9 @@ type handler struct {
 	prefix          string
 	baseURL         string
 	csrfTokenSecret string
-	product         Product
+
+	// Product settings
+	product productConfig
 
 	finderFn     func(token string) (Emailable, error)
 	senderFn     func(message *Message) error

--- a/logger_test.go
+++ b/logger_test.go
@@ -40,10 +40,7 @@ func (sl *stringLogger) Errorf(format string, args ...interface{}) {
 
 func TestCustomLogger(t *testing.T) {
 	lg := &stringLogger{}
-	h, err := maildoor.New(maildoor.Options{
-		CSRFTokenSecret: "secret",
-		Logger:          lg,
-	})
+	h, err := maildoor.NewWithOptions("secret", maildoor.UseLogger(lg))
 
 	testhelpers.NoError(t, err)
 	w := httptest.NewRecorder()

--- a/login_test.go
+++ b/login_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	h, err := maildoor.New(maildoor.Options{
-		CSRFTokenSecret: "secret",
-	})
+	h, err := maildoor.NewWithOptions("secret")
 
 	testhelpers.NoError(t, err)
 

--- a/logout_test.go
+++ b/logout_test.go
@@ -10,14 +10,12 @@ import (
 )
 
 func TestLogout(t *testing.T) {
-	h, err := maildoor.New(maildoor.Options{
-		CSRFTokenSecret: "secret",
-		LogoutFn: func(w http.ResponseWriter, r *http.Request) error {
-			http.Redirect(w, r, "/", http.StatusSeeOther)
-			return nil
-		},
-	})
+	logout := func(w http.ResponseWriter, r *http.Request) error {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return nil
+	}
 
+	h, err := maildoor.NewWithOptions("secret", maildoor.UseLogout(logout))
 	testhelpers.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/maildoor_test.go
+++ b/maildoor_test.go
@@ -9,21 +9,12 @@ import (
 func TestNew(t *testing.T) {
 	tcases := []struct {
 		name   string
-		opts   Options
+		opts   []Option
 		verify func(*testing.T, *handler, error)
 	}{
 		{
-			name: "totally empty it errors",
-			opts: Options{},
-			verify: func(t *testing.T, h *handler, err error) {
-				testhelpers.Error(t, err)
-			},
-		},
-		{
 			name: "empty defaults",
-			opts: Options{
-				CSRFTokenSecret: "secret",
-			},
+			opts: []Option{},
 			verify: func(t *testing.T, h *handler, err error) {
 				testhelpers.NoError(t, err)
 				testhelpers.NotEquals(t, "", h.product.Name)
@@ -39,13 +30,10 @@ func TestNew(t *testing.T) {
 
 		{
 			name: "some empty defaults",
-			opts: Options{
-				CSRFTokenSecret: "secret",
-				Product: Product{
-					Name:       "MyProduct",
-					LogoURL:    "logoURL",
-					FaviconURL: "faviconURL",
-				},
+			opts: []Option{
+				UseProductName("MyProduct"),
+				UseLogo("logoURL"),
+				UseFavicon("faviconURL"),
 			},
 			verify: func(t *testing.T, h *handler, err error) {
 				testhelpers.NoError(t, err)
@@ -71,9 +59,7 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "product images",
-			opts: Options{
-				CSRFTokenSecret: "secret",
-			},
+			opts: []Option{},
 			verify: func(t *testing.T, h *handler, err error) {
 				testhelpers.NoError(t, err)
 				testhelpers.NotEquals(t, "", h.product.Name)
@@ -90,9 +76,14 @@ func TestNew(t *testing.T) {
 
 	for _, v := range tcases {
 		t.Run(v.name, func(tt *testing.T) {
-			h, err := New(v.opts)
+			h, err := NewWithOptions("secret", v.opts...)
 			v.verify(tt, h, err)
 		})
 	}
 
+}
+
+func TestEmptyToken(t *testing.T) {
+	_, err := NewWithOptions("")
+	testhelpers.Error(t, err)
 }

--- a/paths.go
+++ b/paths.go
@@ -17,11 +17,3 @@ func (h handler) validatePath() string {
 func (h handler) stylesPath() string {
 	return h.baseURL + path.Join(h.prefix, "/assets/styles/maildoor.min.css")
 }
-
-func (h handler) logoPath() string {
-	return h.baseURL + path.Join(h.prefix, "/assets/images/maildoor_logo.png")
-}
-
-func (h handler) faviconPath() string {
-	return h.baseURL + path.Join(h.prefix, "/assets/images/favicon.png")
-}

--- a/productconfig.go
+++ b/productconfig.go
@@ -1,0 +1,10 @@
+package maildoor
+
+// productConfig options allow to customize the productConfig name and logo
+// as well as the favicon. These are used in the email that gets
+// sent to the user and the login form.
+type productConfig struct {
+	Name       string
+	LogoURL    string
+	FaviconURL string
+}

--- a/send.go
+++ b/send.go
@@ -81,11 +81,13 @@ func (h *handler) composeMessage(user Emailable, link string) (*Message, error) 
 		Logo      string
 		Year      string
 		LoginLink string
+		BaseURL   string
 	}{
 		Product:   h.product.Name,
 		Logo:      h.product.LogoURL,
 		Year:      time.Now().Format("2006"),
 		LoginLink: link,
+		BaseURL:   h.baseURL,
 	}
 
 	bb := bytes.NewBuffer([]byte{})

--- a/templates/message.html.email
+++ b/templates/message.html.email
@@ -426,14 +426,13 @@
   <![endif]-->
   </head>
   <body>
-    <!-- <span class="preheader"></span> -->
     <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
       <tr>
         <td align="center">
           <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
             <tr>
               <td class="email-masthead">
-                <a href="https://example.com" class="f-fallback email-masthead_name" >
+                <a href="{{.BaseURL}}" class="f-fallback email-masthead_name" >
                   <img src="{{.Logo}}" style="width: 200px !important;" alt="application logo">
                 </a>
               </td>
@@ -454,8 +453,6 @@
                         <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
                           <tr>
                             <td align="center">
-                              <!-- Border based button
-           https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design -->
                               <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
                                 <tr>
                                   <td align="center">

--- a/validate_test.go
+++ b/validate_test.go
@@ -15,17 +15,18 @@ func TestValidate(t *testing.T) {
 
 	t.Run("Everything Valid", func(tt *testing.T) {
 		var alcld = false
-		h, err := maildoor.New(maildoor.Options{
-			CSRFTokenSecret: "secret",
-			FinderFn: func(token string) (maildoor.Emailable, error) {
-				return testUser("amail@mail.com"), nil
-			},
+		h, err := maildoor.NewWithOptions(
+			"secret",
 
-			AfterLoginFn: func(w http.ResponseWriter, r *http.Request, user maildoor.Emailable) error {
+			maildoor.UseFinder(func(token string) (maildoor.Emailable, error) {
+				return testUser("amail@mail.com"), nil
+			}),
+
+			maildoor.UseAfterLogin(func(w http.ResponseWriter, r *http.Request, user maildoor.Emailable) error {
 				alcld = true
 				return nil
-			},
-		})
+			}),
+		)
 
 		testhelpers.NoError(t, err)
 
@@ -41,12 +42,12 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("expired token", func(tt *testing.T) {
-		h, err := maildoor.New(maildoor.Options{
-			CSRFTokenSecret: "secret",
-			FinderFn: func(token string) (maildoor.Emailable, error) {
+		h, err := maildoor.NewWithOptions(
+			"secret",
+			maildoor.UseFinder(func(token string) (maildoor.Emailable, error) {
 				return testUser("amail@mail.com"), nil
-			},
-		})
+			}),
+		)
 
 		testhelpers.NoError(t, err)
 
@@ -63,12 +64,12 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("finder error", func(tt *testing.T) {
-		h, err := maildoor.New(maildoor.Options{
-			CSRFTokenSecret: "secret",
-			FinderFn: func(token string) (maildoor.Emailable, error) {
+		h, err := maildoor.NewWithOptions(
+			"secret",
+			maildoor.UseFinder(func(token string) (maildoor.Emailable, error) {
 				return nil, fmt.Errorf("error finding")
-			},
-		})
+			}),
+		)
 
 		testhelpers.NoError(t, err)
 
@@ -85,12 +86,12 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("nil user returned", func(tt *testing.T) {
-		h, err := maildoor.New(maildoor.Options{
-			CSRFTokenSecret: "secret",
-			FinderFn: func(token string) (maildoor.Emailable, error) {
+		h, err := maildoor.NewWithOptions(
+			"secret",
+			maildoor.UseFinder(func(token string) (maildoor.Emailable, error) {
 				return nil, nil
-			},
-		})
+			}),
+		)
 
 		testhelpers.NoError(t, err)
 
@@ -108,17 +109,18 @@ func TestValidate(t *testing.T) {
 
 	t.Run("nil user returned", func(tt *testing.T) {
 		var alcld bool
-		h, err := maildoor.New(maildoor.Options{
-			CSRFTokenSecret: "secret",
-			FinderFn: func(token string) (maildoor.Emailable, error) {
-				return testUser("email@email.com"), nil
-			},
 
-			AfterLoginFn: func(w http.ResponseWriter, r *http.Request, user maildoor.Emailable) error {
+		h, err := maildoor.NewWithOptions(
+			"secret",
+			maildoor.UseFinder(func(token string) (maildoor.Emailable, error) {
+				return testUser("email@email.com"), nil
+			}),
+
+			maildoor.UseAfterLogin(func(w http.ResponseWriter, r *http.Request, user maildoor.Emailable) error {
 				alcld = true
 				return fmt.Errorf("error here")
-			},
-		})
+			}),
+		)
 
 		testhelpers.NoError(t, err)
 


### PR DESCRIPTION
This PR moves the configuration of the handler to be done using the options pattern. That opens the door for adding a lot of configurations for the package without maintaining an `Options` struct.