### PR TITLE
Handling prefix

### DIFF
--- a/handle_login_test.go
+++ b/handle_login_test.go
@@ -31,7 +31,7 @@ func TestHandleLogin(t *testing.T) {
 	})
 
 	t.Run("using prefix", func(t *testing.T) {
-		auth := maildoor.New(maildoor.Prefix("/auth"), maildoor.AcceptPrefix(true))
+		auth := maildoor.New(maildoor.Prefix("/auth"), maildoor.IncludePrefix(true))
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
 
@@ -45,7 +45,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.Logo("https://my.logo/image.png"),
-			maildoor.AcceptPrefix(true),
+			maildoor.IncludePrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.Icon("https://my.icon/image.png"),
-			maildoor.AcceptPrefix(true),
+			maildoor.IncludePrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -77,7 +77,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.ProductName("My App"),
-			maildoor.AcceptPrefix(true),
+			maildoor.IncludePrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -95,7 +95,7 @@ func TestHandleLogin(t *testing.T) {
 			maildoor.Logo("https://my.logo/image.png"),
 			maildoor.Icon("https://my.icon/image.png"),
 			maildoor.ProductName("My App"),
-			maildoor.AcceptPrefix(true),
+			maildoor.IncludePrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()

--- a/handle_login_test.go
+++ b/handle_login_test.go
@@ -31,7 +31,7 @@ func TestHandleLogin(t *testing.T) {
 	})
 
 	t.Run("using prefix", func(t *testing.T) {
-		auth := maildoor.New(maildoor.Prefix("/auth"))
+		auth := maildoor.New(maildoor.Prefix("/auth"), maildoor.AcceptPrefix(true))
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
 
@@ -45,6 +45,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.Logo("https://my.logo/image.png"),
+			maildoor.AcceptPrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -60,6 +61,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.Icon("https://my.icon/image.png"),
+			maildoor.AcceptPrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -75,6 +77,7 @@ func TestHandleLogin(t *testing.T) {
 		auth := maildoor.New(
 			maildoor.Prefix("/auth"),
 			maildoor.ProductName("My App"),
+			maildoor.AcceptPrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()
@@ -92,6 +95,7 @@ func TestHandleLogin(t *testing.T) {
 			maildoor.Logo("https://my.logo/image.png"),
 			maildoor.Icon("https://my.icon/image.png"),
 			maildoor.ProductName("My App"),
+			maildoor.AcceptPrefix(true),
 		)
 		req := httptest.NewRequest("GET", "/auth/login", nil)
 		w := httptest.NewRecorder()

--- a/internal/sample/auth.go
+++ b/internal/sample/auth.go
@@ -18,9 +18,10 @@ import (
 // and after login function
 var Auth = maildoor.New(
 	maildoor.Prefix("/auth/"),
+	maildoor.AcceptPrefix(true),
 	maildoor.Icon("https://raw.githubusercontent.com/wawandco/maildoor/5de0561/internal/sample/logo.png"),
 	maildoor.Logo("https://raw.githubusercontent.com/wawandco/maildoor/5de0561/internal/sample/logo.png"),
-	maildoor.ProductName("Basse"),
+	maildoor.ProductName("Sample"),
 	maildoor.EmailValidator(validateEmail),
 	maildoor.AfterLogin(afterLogin),
 	maildoor.EmailSender(sendEmail),

--- a/internal/sample/auth.go
+++ b/internal/sample/auth.go
@@ -18,7 +18,7 @@ import (
 // and after login function
 var Auth = maildoor.New(
 	maildoor.Prefix("/auth/"),
-	maildoor.AcceptPrefix(true),
+	maildoor.IncludePrefix(true),
 	maildoor.Icon("https://raw.githubusercontent.com/wawandco/maildoor/5de0561/internal/sample/logo.png"),
 	maildoor.Logo("https://raw.githubusercontent.com/wawandco/maildoor/5de0561/internal/sample/logo.png"),
 	maildoor.ProductName("Sample"),

--- a/maildoor.go
+++ b/maildoor.go
@@ -58,9 +58,13 @@ func New(options ...option) http.Handler {
 	}
 
 	s.HandleFunc("GET /login", s.handleLogin)
+	s.HandleFunc("GET /login/{$}", s.handleLogin)
 	s.HandleFunc("POST /email", s.handleEmail)
+	s.HandleFunc("POST /email/{$}", s.handleEmail)
 	s.HandleFunc("POST /code", s.handleCode)
+	s.HandleFunc("POST /code/{$}", s.handleCode)
 	s.HandleFunc("DELETE /logout", s.handleLogout)
+	s.HandleFunc("DELETE /logout/{$}", s.handleLogout)
 
 	// Adding the static assets handler
 	ah := http.StripPrefix(s.patternPrefix, http.FileServer(http.FS(assets)))
@@ -76,6 +80,7 @@ type maildoor struct {
 	logoURL     string
 	iconURL     string
 
+	acceptPrefix  bool
 	patternPrefix string
 	afterLogin    http.HandlerFunc
 	logout        http.HandlerFunc
@@ -85,6 +90,11 @@ type maildoor struct {
 }
 
 func (m *maildoor) HandleFunc(pattern string, handler http.HandlerFunc) {
+	if !m.acceptPrefix {
+		m.mux.HandleFunc(pattern, handler)
+		return
+	}
+
 	// prefix the pattens with the routesPrefix
 	parts := strings.Split(pattern, " ")
 	pattern = path.Join(m.patternPrefix, parts[0])
@@ -98,6 +108,11 @@ func (m *maildoor) HandleFunc(pattern string, handler http.HandlerFunc) {
 }
 
 func (m *maildoor) Handle(pattern string, handler http.Handler) {
+	if !m.acceptPrefix {
+		m.mux.Handle(pattern, handler)
+		return
+	}
+
 	// prefix the pattens with the routesPrefix
 	parts := strings.Split(pattern, " ")
 	pattern = path.Join(m.patternPrefix, parts[0])

--- a/maildoor.go
+++ b/maildoor.go
@@ -80,7 +80,7 @@ type maildoor struct {
 	logoURL     string
 	iconURL     string
 
-	acceptPrefix  bool
+	includePrefix bool
 	patternPrefix string
 	afterLogin    http.HandlerFunc
 	logout        http.HandlerFunc
@@ -90,7 +90,7 @@ type maildoor struct {
 }
 
 func (m *maildoor) HandleFunc(pattern string, handler http.HandlerFunc) {
-	if !m.acceptPrefix {
+	if !m.includePrefix {
 		m.mux.HandleFunc(pattern, handler)
 		return
 	}
@@ -108,7 +108,7 @@ func (m *maildoor) HandleFunc(pattern string, handler http.HandlerFunc) {
 }
 
 func (m *maildoor) Handle(pattern string, handler http.Handler) {
-	if !m.acceptPrefix {
+	if !m.includePrefix {
 		m.mux.Handle(pattern, handler)
 		return
 	}

--- a/options.go
+++ b/options.go
@@ -21,10 +21,10 @@ func ProductName(p string) option {
 	}
 }
 
-// AcceptPrefix sets if the prefix should be accepted or not.
-func AcceptPrefix(ok bool) option {
+// IncludePrefix sets if the prefix should be accepted or not.
+func IncludePrefix(ok bool) option {
 	return func(m *maildoor) {
-		m.acceptPrefix = ok
+		m.includePrefix = ok
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -21,6 +21,13 @@ func ProductName(p string) option {
 	}
 }
 
+// AcceptPrefix sets if the prefix should be accepted or not.
+func AcceptPrefix(ok bool) option {
+	return func(m *maildoor) {
+		m.acceptPrefix = ok
+	}
+}
+
 // Prefix sets the prefix for the routes. By default it is /auth/.
 func Prefix(p string) option {
 	return func(m *maildoor) {
@@ -28,6 +35,7 @@ func Prefix(p string) option {
 	}
 }
 
+// Icon sets the favicon for the pages.
 func Icon(i string) option {
 	return func(m *maildoor) {
 		m.iconURL = i


### PR DESCRIPTION
## Description ##
This PR is to give the user the ability to handle their prefix by including it to the path or not

## Changes ##
- Create a new field called includePrefix
- Create a new option called IncludePrefix
- Support routes that end with / 